### PR TITLE
Update protocol from git to https

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ libmodbus:
 		  echo "****** Damaged libmodbus directory. Remove it!" >&2; exit 1;\
 		fi; \
 	 else\
-		git clone git://github.com/stephane/libmodbus;\
+		git clone https://github.com/stephane/libmodbus;\
 	 fi
 	@cd libmodbus;\
 	 ./autogen.sh;\


### PR DESCRIPTION
Unencrypted git protocol got removed by git. It now throws an error:
'''
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
'''
Changing to https to fix this.